### PR TITLE
Decouple cache prompting from model support and refactor to LLM space

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -182,7 +182,7 @@ class CodeActAgent(Agent):
             'temperature': 0.0,
         }
 
-        if self.llm.supports_prompt_caching:
+        if self.llm.prompt_caching:
             params['extra_headers'] = {
                 'anthropic-beta': 'prompt-caching-2024-07-31',
             }
@@ -198,7 +198,7 @@ class CodeActAgent(Agent):
                 content=[
                     TextContent(
                         text=self.prompt_manager.system_message,
-                        cache_prompt=self.llm.supports_prompt_caching,  # Cache system prompt
+                        cache_prompt=True
                     )
                 ],
             ),
@@ -207,7 +207,7 @@ class CodeActAgent(Agent):
                 content=[
                     TextContent(
                         text=self.prompt_manager.initial_user_message,
-                        cache_prompt=self.llm.supports_prompt_caching,  # if the user asks the same query,
+                        cache_prompt=True
                     )
                 ],
             ),

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -182,11 +182,6 @@ class CodeActAgent(Agent):
             'temperature': 0.0,
         }
 
-        if self.llm.prompt_caching:
-            params['extra_headers'] = {
-                'anthropic-beta': 'prompt-caching-2024-07-31',
-            }
-
         response = self.llm.completion(**params)
 
         return self.action_parser.parse(response)

--- a/agenthub/codeact_swe_agent/codeact_swe_agent.py
+++ b/agenthub/codeact_swe_agent/codeact_swe_agent.py
@@ -170,8 +170,8 @@ class CodeActSWEAgent(Agent):
 
     def _get_messages(self, state: State) -> list[Message]:
         messages: list[Message] = [
-            Message(role='system', content=[TextContent(text=self.system_message)]),
-            Message(role='user', content=[TextContent(text=self.in_context_example)]),
+            Message(role='system', content=[TextContent(text=self.system_message, cache_prompt=True)]),
+            Message(role='user', content=[TextContent(text=self.in_context_example, cache_prompt=True)]),
         ]
 
         for event in state.history.get_events():

--- a/openhands/core/config.py
+++ b/openhands/core/config.py
@@ -21,6 +21,10 @@ LLM_SENSITIVE_FIELDS = ['api_key', 'aws_access_key_id', 'aws_secret_access_key']
 _DEFAULT_AGENT = 'CodeActAgent'
 _MAX_ITERATIONS = 100
 
+PROMPT_CACHE_SUPPORTED_KNOWN_MODELS = [
+    'claude-3-5-sonnet-20240620',
+    'claude-3-haiku-20240307',
+]
 
 @dataclass
 class LLMConfig:
@@ -79,6 +83,12 @@ class LLMConfig:
     output_cost_per_token: float | None = None
     ollama_base_url: str | None = None
     drop_params: bool | None = None
+    prompt_caching: bool = False
+
+    def enable_prompt_caching_known_models(self):
+        self.prompt_caching = (
+            self.model in PROMPT_CACHE_SUPPORTED_KNOWN_MODELS
+        )
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""
@@ -99,6 +109,9 @@ class LLMConfig:
             attr_str.append(f'{attr_name}={repr(attr_value)}')
 
         return f"LLMConfig({', '.join(attr_str)})"
+
+    def __post_init__(self):
+        self.enable_prompt_caching_known_models()
 
     def __repr__(self):
         return self.__str__()

--- a/openhands/core/config.py
+++ b/openhands/core/config.py
@@ -84,11 +84,16 @@ class LLMConfig:
     ollama_base_url: str | None = None
     drop_params: bool | None = None
     prompt_caching: bool = False
+    extra_headers: dict | None = None
 
     def enable_prompt_caching_known_models(self):
         self.prompt_caching = (
             self.model in PROMPT_CACHE_SUPPORTED_KNOWN_MODELS
         )
+        if self.prompt_caching:
+            self.extra_headers = {
+                'anthropic-beta': 'prompt-caching-2024-07-31',
+            }
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""

--- a/openhands/core/message.py
+++ b/openhands/core/message.py
@@ -29,7 +29,7 @@ class TextContent(Content):
             'text': self.text,
         }
         if self.cache_prompt:
-            data['cache_control'] = {'type': 'ephemeral'}
+            data['cache_prompt'] = True
         return data
 
 
@@ -43,7 +43,7 @@ class ImageContent(Content):
         for url in self.image_urls:
             images.append({'type': self.type.value, 'image_url': {'url': url}})
         if self.cache_prompt and images:
-            images[-1]['cache_control'] = {'type': 'ephemeral'}
+            images[-1]['cache_prompt'] = True
         return images
 
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -112,6 +112,7 @@ class LLM:
             timeout=self.config.timeout,
             temperature=self.config.temperature,
             top_p=self.config.top_p,
+            extra_headers=self.config.extra_headers
         )
 
         completion_unwrapped = self._completion

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,18 +18,18 @@ script_dir = os.environ.get('SCRIPT_DIR')
 project_root = os.environ.get('PROJECT_ROOT')
 workspace_path = os.environ.get('WORKSPACE_BASE')
 test_runtime = os.environ.get('TEST_RUNTIME')
-MOCK_ROOT_DIR = os.path.join(
-    script_dir,
-    'mock',
-    f'{test_runtime}_runtime',
-    os.environ.get('DEFAULT_AGENT'),
-)
 
 assert script_dir is not None, 'SCRIPT_DIR environment variable is not set'
 assert project_root is not None, 'PROJECT_ROOT environment variable is not set'
 assert workspace_path is not None, 'WORKSPACE_BASE environment variable is not set'
 assert test_runtime is not None, 'TEST_RUNTIME environment variable is not set'
 
+MOCK_ROOT_DIR = os.path.join(
+    script_dir,
+    'mock',
+    f'{test_runtime}_runtime',
+    os.environ.get('DEFAULT_AGENT'),
+)
 
 class SecretExit(Exception):
     pass


### PR DESCRIPTION
1. Added support for users to disable prompt caching, even for supported models.
2. Added support for users to enable prompt caching beyond hardcoded supported models.
3. Added directional expansion for concrete formatting as more models and prompt settings emerge. This moves the dictionary syntax update from the `Message` class to the `LLM` class. The justification for this change is that the LLM controls the caching on/off state and format. This change provides a clear point for future expansion as formatting evolves for different models or changes over time. Additionally, this change improves the separation of our internal representation. For example, in the case of Google Gemini, there are additional cache settings. https://ai.google.dev/gemini-api/docs/caching?lang=python

In summary it separates all of the concerns of:
* Intent to cache a specific type of message 
* Intent to turn on/off caching
* Model supporting caching
* Model caching syntax

I haven't worked with this codebase before so please forgive me if I'm suggesting something off base. 

